### PR TITLE
[Feature #163674123] Implementation of `/parties/<party_id>` endpoint

### DIFF
--- a/politico.py
+++ b/politico.py
@@ -28,13 +28,32 @@ def create_political_party():
         return make_response(jsonify(error_message), 400)
     # Append to the list of parties.
     parties.append(party)
-    response = {"status": 201, "data": [{"id": party["id"], "name": party["name"]}]}
+    response = {"status": 201, "data": [
+        {"id": party["id"], "name": party["name"]}]}
     return make_response(jsonify(response), 201)
 
 
 @app.route("/parties", methods=["GET"])
 def get_all_political_parties():
     response = {"status": 200, "data": parties}
+    return make_response(jsonify(response), 200)
+
+
+@app.route("/parties/<int:party_id>", methods=["GET"])
+def get_specific_political_party(party_id):
+    party = [party for party in parties if party["id"] == party_id]
+    print(party)
+    if len(party) == 0:
+        error_message = {
+            "status": 404,
+            "message": f"Party with party-id {party_id} NOT FOUND.",
+        }
+        return make_response(jsonify(error_message), 404)
+    fields = ["id", "name", "logoUrl"]
+    party_to_return = {}
+    for field in fields:
+        party_to_return[field] = party[0][field]
+    response = {"status": 200, "data": [party_to_return]}
     return make_response(jsonify(response), 200)
 
 

--- a/test_politico.py
+++ b/test_politico.py
@@ -27,5 +27,17 @@ def test_get_all_political_parties():
     assert response.status_code == 200
 
 
+def test_get_specific_political_party():
+    # party with <party_id> 1 has been created thus party should be found
+    response = client.get("/parties/1")
+    assert response.status_code == 200
+
+
+def test_get_specific_nonexistent_political_party():
+    # party with <party_id> 5 has not been created thus party should not be found
+    response = client.get("/parties/5")
+    assert response.status_code == 404
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
#### What does this PR do?
Implements the '/parties/<int:party_id>' endpoint of the Politico REST API for fetching a specific political party.

#### Description of tasks to be completed?
Fetch a specific party by sending a `GET` request to `/parties/<party_id>` where `<party_id>` is a unique id for the specific political party.

#### How can this be manually tested?
After cloning the repo, cd into it and run python politico.py, the app should be served via localhost post 5000
Using an API client, for instance Postman, send a `GET` request to the '/parties/<party_id>' endpoint where `<party_id>` is a unique id for the specific political party. If no political party matches the provided `<party_id>`, a `404 NOT FOUND` error is returned.

#### Any background context to be provided?
Make sure to have the flask and pytest (and the other libraries in requirements.txt) installed.

#### Relevant Pivotal Tracker stories?
#163674123